### PR TITLE
Update partner_benefits.md SecureFlag Platform link

### DIFF
--- a/pages/partner_benefits.md
+++ b/pages/partner_benefits.md
@@ -13,7 +13,7 @@ permalink: /partner_benefits/
 [![Checkmarx Codebashing](https://owasp.org/assets/images/corp-member-logo/Codebashing-Final-Logos_Horizontal-Logo-BLK.png){:width="300px"}](https://checkmarx.com/codebashing/owasp/?utm_source=PR&utm_medium=referral&utm_campaign=Checkmarx_and_OWASP_Launch)<br>
 Application security training and certification for everyone from beginning developers to experienced managers.
 <hr>
-[![SecureFlag Platform](https://owasp.org/assets/images/corp-member-logo/secureflagposhighres_copy.png){:width="200px"}](https://www.secureflag.com/owasp.html)<br>
+[![SecureFlag Platform](https://owasp.org/assets/images/corp-member-logo/secureflagposhighres_copy.png){:width="200px"}](https://www.secureflag.com/owasp)<br>
 Hands-on application security training
 <hr>
 [![Ubiq](/assets/images/corporate/ubiq_logo.png){:width="200px"}](https://dashboard.ubiqsecurity.com)<br>


### PR DESCRIPTION
The link to the SecureFlag Platform was broken because of .html extension.